### PR TITLE
Patch/add resetslot method

### DIFF
--- a/src/Advertising.js
+++ b/src/Advertising.js
@@ -125,6 +125,12 @@ export default class Advertising {
         this[setDefaultConfig]();
     }
 
+    resetSlot(id) {
+        if (window.pbjs[id]) {
+            window.pbjs[id] = false;
+        }
+    }
+
     // ---------- PRIVATE METHODS ----------
 
     [callAdserverSetup](slots) {

--- a/src/components/AdvertisingProvider.js
+++ b/src/components/AdvertisingProvider.js
@@ -81,6 +81,7 @@ export default class AdvertisingProvider extends Component {
         const { advertising, shouldRefresh } = this.state;
         const data = {
             activate: advertising.activate.bind(this.state.advertising),
+            resetSlot: advertising.resetSlot.bind(this.state.advertising),
             active: this.props.active,
             shouldRefresh
         };

--- a/src/components/AdvertisingProvider.test.js
+++ b/src/components/AdvertisingProvider.test.js
@@ -6,6 +6,7 @@ import { mount } from 'enzyme';
 import { config } from '../utils/testAdvertisingConfig';
 
 const mockActivate = spy();
+const mockResetSlot = spy();
 const mockSetup = spy();
 const mockTeardown = spy();
 const mockConstructor = spy();
@@ -31,6 +32,9 @@ jest.mock(
             }
             activate(...args) {
                 mockActivate(...args);
+            }
+            resetSlot(...args) {
+                mockResetSlot(...args);
             }
             setup(...args) {
                 mockSetup(...args);
@@ -87,6 +91,7 @@ describe('The AdvertisingProvider component', () => {
                     setConfig: mockSetConfig,
                     isConfigReady: mockIsConfigNotReady,
                     activate: mockActivate,
+                    resetSlot: mockResetSlot,
                     teardown: mockTeardown
                 }
             });
@@ -104,6 +109,7 @@ describe('The AdvertisingProvider component', () => {
                     setConfig: mockSetConfig,
                     isConfigReady: mockIsConfigReady,
                     activate: mockActivate,
+                    resetSlot: mockResetSlot,
                     teardown: mockTeardown
                 }
             });
@@ -133,6 +139,7 @@ describe('The AdvertisingProvider component', () => {
                 advertising: {
                     isConfigReady: mockIsConfigReady,
                     activate: mockActivate,
+                    resetSlot: mockResetSlot,
                     teardown: mockTeardown
                 }
             });
@@ -151,7 +158,9 @@ describe('The AdvertisingProvider component', () => {
         let component, componentWillUnmount;
         beforeEach(() => {
             component = mount(<AdvertisingProvider />);
-            component.setState({ advertising: { isConfigReady: mockIsConfigReady, activate: mockActivate } });
+            component.setState({
+                advertising: { isConfigReady: mockIsConfigReady, activate: mockActivate, resetSlot: mockResetSlot }
+            });
             componentWillUnmount = jest.spyOn(component.instance(), 'componentWillUnmount');
             component.unmount();
         });

--- a/src/components/AdvertisingSlot.js
+++ b/src/components/AdvertisingSlot.js
@@ -19,6 +19,13 @@ class AdvertisingSlot extends Component {
         }
     }
 
+    componentWillUnmount() {
+        const { active, id, resetSlot } = this.props;
+        if (active) {
+            resetSlot(id);
+        }
+    }
+
     render() {
         const { id, style, className, children } = this.props;
         return <div id={id} style={style} className={className} children={children} />;
@@ -33,6 +40,7 @@ AdvertisingSlot.propTypes = {
     className: PropTypes.string,
     children: PropTypes.node,
     activate: PropTypes.func,
+    resetSlot: PropTypes.func,
     customEventHandlers: PropTypes.objectOf(PropTypes.func).isRequired
 };
 

--- a/src/components/__snapshots__/AdvertisingProvider.test.js.snap
+++ b/src/components/__snapshots__/AdvertisingProvider.test.js.snap
@@ -4,6 +4,7 @@ exports[`The AdvertisingProvider component componentDidUpdate uses an Advertisin
 Object {
   "activate": [Function],
   "active": true,
+  "resetSlot": [Function],
   "shouldRefresh": false,
 }
 `;
@@ -22,6 +23,7 @@ exports[`The AdvertisingProvider component when mounted uses an AdvertisingConte
 Object {
   "activate": [Function],
   "active": true,
+  "resetSlot": [Function],
   "shouldRefresh": false,
 }
 `;

--- a/src/components/utils/connectToAdServer.js
+++ b/src/components/utils/connectToAdServer.js
@@ -3,8 +3,14 @@ import AdvertisingContext from '../../AdvertisingContext';
 
 export default Component => props => (
     <AdvertisingContext.Consumer>
-        {({ activate, active, shouldRefresh }) => (
-            <Component {...props} activate={activate} active={active} shouldRefresh={shouldRefresh} />
+        {({ activate, active, shouldRefresh, resetSlot }) => (
+            <Component
+                {...props}
+                activate={activate}
+                active={active}
+                shouldRefresh={shouldRefresh}
+                resetSlot={resetSlot}
+            />
         )}
     </AdvertisingContext.Consumer>
 );


### PR DESCRIPTION
### what is the change

> Added: `resetSlot` method. Will be called before `AdvertisingSlot` gets unmount, to reset flag prevent double firing the biding request